### PR TITLE
Fix llama index response mode and dependency pins

### DIFF
--- a/ai_engine.py
+++ b/ai_engine.py
@@ -18,6 +18,7 @@ from llama_index.core import (
 )
 from llama_index.core.settings import Settings
 from llama_index.core.postprocessor import SentenceTransformerRerank
+from llama_index.core.response_synthesizers import ResponseMode
 from llama_index.embeddings.huggingface import HuggingFaceEmbedding
 from langchain_google_genai import GoogleGenerativeAI
 
@@ -343,7 +344,7 @@ def get_answer(question: str):
         prompt_template=COMBINE_PROMPT,
         graph_query_kwargs={"top_k": NUM_INDICES},
         child_query_kwargs=child_kwargs,
-        response_mode="map_rerank",
+        response_mode=ResponseMode.COMPACT,
     )
     if node_postprocessors:
         query_engine_kwargs["node_postprocessors"] = node_postprocessors

--- a/ai_engine_gemini.py
+++ b/ai_engine_gemini.py
@@ -18,6 +18,7 @@ from llama_index.core import (
 )
 from llama_index.core.settings import Settings
 from llama_index.core.postprocessor import SentenceTransformerRerank
+from llama_index.core.response_synthesizers import ResponseMode
 
 # ── 変更点: 埋め込みを HuggingFace(E5) → Google Gemini Embedding に切替 ──
 # 旧: from llama_index.embeddings.huggingface import HuggingFaceEmbedding
@@ -359,7 +360,7 @@ def get_answer(question: str):
         prompt_template=COMBINE_PROMPT,
         graph_query_kwargs={"top_k": NUM_INDICES},
         child_query_kwargs=child_kwargs,
-        response_mode="map_rerank",
+        response_mode=ResponseMode.COMPACT,
     )
     if node_postprocessors:
         query_engine_kwargs["node_postprocessors"] = node_postprocessors

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ numpy==2.2.4
 google-generativeai
 langchain==0.3.23
 langchain-community==0.3.21
-langchain_google_genai== 2.0.10
+langchain_google_genai==2.0.10
 langchain_google_vertexai==2.0.20
 
 sentence-transformers
@@ -15,4 +15,4 @@ llama-index==0.12.30
 llama-index-embeddings-huggingface==0.5.3
 llama-index-core==0.12.30
 llama-index-llms-langchain==0.6.1
-llama_index.embeddings.google_genai
+llama-index-embeddings-google-genai==0.2.1


### PR DESCRIPTION
## Summary
- switch the query engine configuration in both ai_engine variants to use ResponseMode.COMPACT now that map_rerank is unavailable
- import the new ResponseMode helper so llama_index can build the response synthesizer without errors
- correct the Google GenAI requirement entries, fixing whitespace and pinning the embeddings package for reproducible installs

## Testing
- python -m compileall ai_engine.py ai_engine_gemini.py
- pip check

------
https://chatgpt.com/codex/tasks/task_e_68d789c149a883209164cbf175e772db