### PR TITLE
Fix query engine response mode and tidy dependencies

### DIFF
--- a/ai_engine.py
+++ b/ai_engine.py
@@ -16,6 +16,7 @@ from llama_index.core import (
     StorageContext,
     PromptHelper,
 )
+from llama_index.core.response_synthesizers import ResponseMode
 from llama_index.core.settings import Settings
 from llama_index.core.postprocessor import SentenceTransformerRerank
 from llama_index.embeddings.huggingface import HuggingFaceEmbedding
@@ -343,7 +344,7 @@ def get_answer(question: str):
         prompt_template=COMBINE_PROMPT,
         graph_query_kwargs={"top_k": NUM_INDICES},
         child_query_kwargs=child_kwargs,
-        response_mode="map_rerank",
+        response_mode=ResponseMode.COMPACT,
     )
     if node_postprocessors:
         query_engine_kwargs["node_postprocessors"] = node_postprocessors

--- a/ai_engine_gemini.py
+++ b/ai_engine_gemini.py
@@ -18,6 +18,7 @@ from llama_index.core import (
 )
 from llama_index.core.settings import Settings
 from llama_index.core.postprocessor import SentenceTransformerRerank
+from llama_index.core.response_synthesizers import ResponseMode
 
 # ── 変更点: 埋め込みを HuggingFace(E5) → Google Gemini Embedding に切替 ──
 # 旧: from llama_index.embeddings.huggingface import HuggingFaceEmbedding
@@ -359,7 +360,7 @@ def get_answer(question: str):
         prompt_template=COMBINE_PROMPT,
         graph_query_kwargs={"top_k": NUM_INDICES},
         child_query_kwargs=child_kwargs,
-        response_mode="map_rerank",
+        response_mode=ResponseMode.COMPACT,
     )
     if node_postprocessors:
         query_engine_kwargs["node_postprocessors"] = node_postprocessors

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ numpy==2.2.4
 google-generativeai
 langchain==0.3.23
 langchain-community==0.3.21
-langchain_google_genai== 2.0.10
+langchain_google_genai==2.0.10
 langchain_google_vertexai==2.0.20
 
 sentence-transformers
@@ -15,4 +15,4 @@ llama-index==0.12.30
 llama-index-embeddings-huggingface==0.5.3
 llama-index-core==0.12.30
 llama-index-llms-langchain==0.6.1
-llama_index.embeddings.google_genai
+llama-index-embeddings-google==0.4.1


### PR DESCRIPTION
## Summary
- update both AI engines to use ResponseMode.COMPACT instead of the removed map_rerank mode
- add the corresponding ResponseMode imports to keep llama-index usage compatible
- correct dependency declarations for langchain_google_genai and ensure the Google embedding extra is pinned

## Testing
- python -m compileall ai_engine.py ai_engine_gemini.py

------
https://chatgpt.com/codex/tasks/task_e_68d789c149a883209164cbf175e772db