### PR TITLE
Fix Docker build by removing unavailable dependencies

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -11,9 +11,7 @@ langchain_google_vertexai==2.0.20
 
 SudachiPy
 sudachidict_core
-wnja
 flagembedding
-llama-index-postprocessor-flagembedding==0.2.0
 sentencepiece
 llama-index==0.12.30
 llama-index-embeddings-huggingface==0.5.3


### PR DESCRIPTION
## Summary
- drop the `wnja` requirement because it is not published on PyPI and the code already treats it as optional
- remove the nonexistent `llama-index-postprocessor-flagembedding` requirement so dependency installation completes

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d7b2b4dee48320b3b0483ab6bfd071