### PR TITLE
Enable CORS and expose conversation history API

### DIFF
--- a/ai_engine_faiss.py
+++ b/ai_engine_faiss.py
@@ -93,6 +93,11 @@ def save_conversation_history(hist):
         logging.exception(f"履歴の保存エラー: {e}")
 
 
+def get_conversation_history():
+    """会話履歴を外部に提供するためのラッパー"""
+    return load_conversation_history()
+
+
 # ── プロンプト ──
 COMBINE_PROMPT = """あなたは、資料を基にユーザーの問いに対してサポートするためのアシスタントです。
 

--- a/app.py
+++ b/app.py
@@ -1,5 +1,6 @@
 # flask_app.py
 from flask import Flask, request, jsonify, render_template
+from flask_cors import CORS
 import os
 import logging
 from dotenv import load_dotenv
@@ -12,6 +13,9 @@ load_dotenv()
 app = Flask(__name__)
 app.secret_key = os.getenv("SECRET_KEY", "default_secret_key")
 logging.basicConfig(level=logging.DEBUG)
+
+# Allow cross-origin requests from any domain without affecting existing logic
+CORS(app)
 
 
 @app.route("/rag_answer", methods=["POST"])
@@ -34,6 +38,13 @@ def reset_history():
     """会話履歴をリセット"""
     ai_engine.reset_history()
     return jsonify({"status": "Conversation history reset."})
+
+
+@app.route("/conversation_history", methods=["GET"])
+def conversation_history():
+    """現在の会話履歴を返す"""
+    history = ai_engine.get_conversation_history()
+    return jsonify({"conversation_history": history})
 
 
 @app.route("/")

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 Flask
+Flask-Cors
 PyPDF2
 python-dotenv
 faiss-cpu


### PR DESCRIPTION
## Summary
- enable Flask-CORS so that external domains can call the Flask endpoints
- add a GET /conversation_history endpoint that returns the saved chat history
- expose a getter in the AI engine and declare the Flask-Cors dependency

## Testing
- python -m compileall app.py ai_engine_faiss.py

------
https://chatgpt.com/codex/tasks/task_e_68dddf4aad688320bbaf1875c0322ec1