### PR TITLE
Connect qasystem service to external multi-agent network

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,4 +5,12 @@ services:
       - "5000:5000"
     volumes:
       - .:/app      # プロジェクト全体を /app にマウント
+    networks:
+      - default
+      - multi_agent_network
+
+networks:
+  multi_agent_network:
+    external: true
+    name: ${MULTI_AGENT_NETWORK:-multi_agent_platform_net}
 


### PR DESCRIPTION
## Summary
- attach the qasystem service to both the default network and a shared multi-agent network
- declare the external network with a configurable name via the MULTI_AGENT_NETWORK variable

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68de1889acfc832089801a5d46ca6623